### PR TITLE
Add explanation of ordinal comparison of strings using the `<` and `>…

### DIFF
--- a/content/actions/learn-github-actions/expressions.md
+++ b/content/actions/learn-github-actions/expressions.md
@@ -78,7 +78,7 @@ env:
 | Operator    | Description |
 | ---         | ---         |
 | `( )`       | Logical grouping |
-| `[ ]`       | Index
+| `[ ]`       | Index |
 | `.`         | Property de-reference |
 | `!`         | Not |
 | `<`         | Less than |
@@ -89,6 +89,16 @@ env:
 | `!=`        | Not equal |
 | `&&`        | And |
 |  <code>\|\|</code> | Or |
+
+{% data variables.product.prodname_dotcom %} performs loose ordinal comparisons.
+
+* If the value is a string, as may be the case for outputs from previous steps in a workflow, the `<` and `>` operators will compare the values in ASCII-betical order.
+  | Expression                       | Result  | Explanation                                                                                                                                                                     |
+  | ---                              | ---     | ---                                                                                                                                                                             |
+  | `'a' < 'b'`                      | `true`  | `'a'` is `61` in ASCII and is less than `'b'` which is `62` in ASCII                                                                                                            |
+  | `'d' < 'c'`                      | `false` | `'d'` is `64` in ASCII and is not less than `'c'` which is `63` in ASCII                                                                                                        |
+  | `'15' < '9'`                     | `true`  | The first character, `'1'`, is `31` in ASCII and is less than `'9'` which is `39` in ASCII, even though `15` is not less than `9` when evaluated as numbers instead of strings. |
+  | `fromJSON('15') < fromJSON('9')` | `false` | The `fromJSON()` function parses `'15'` and `'9'` as numbers, and `15` is not less than `9`.                                                                                    |
 
 {% data variables.product.prodname_dotcom %} performs loose equality comparisons.
 


### PR DESCRIPTION
…` operators

The `<` and `>` operators, and by extension the `<=` and `>=` operators, will behave unexpectedly when evaluating `steps.*.outputs.*`  values, because these values will be compared as strings. So for example `'10000' > '2'` evaluates to false. This can lead to unexpected behaviour when used in `if: ${{ ... }}` conditional steps and should be documented.

See also: https://github.com/orgs/community/discussions/57480

<!--
Thank you for contributing to this project! You must fill out the information below before we can review this pull request. By explaining why you're making a change (or linking to an issue) and what changes you've made, we can triage your pull request to the best possible team for review.
-->

### Why:

Closes: 

<!-- If there's an existing issue for your change, please link to it above.
If there's _not_ an existing issue, please open one first to make it more likely that this update will be accepted: https://github.com/github/docs/issues/new/choose. -->

### What's being changed (if available, include any code snippets, screenshots, or gifs):

<!-- Let us know what you are changing. Share anything that could provide the most context.
If you made changes to the `content` directory, a table will populate in a comment below with links to the preview and current production articles. -->

### Check off the following:

- [ ] I have reviewed my changes in staging, available via the **View deployment** link in this PR's timeline.

  - For content changes, you will also see an automatically generated comment with links directly to pages you've modified. The comment won't appear if your PR only edits files in the `data` directory.
- [ ] For content changes, I have completed the [self-review checklist](https://github.com/github/docs/blob/main/contributing/self-review.md#self-review).
